### PR TITLE
fix rto for keepalive

### DIFF
--- a/ustack/gonet/gonet.go
+++ b/ustack/gonet/gonet.go
@@ -247,9 +247,9 @@ func NewTCPConn(wq *waiter.Queue, ep tcpip.Endpoint) *TCPConn {
 		count    = 3
 	)
 	ep.SocketOptions().SetKeepAlive(true)
-	ep.SetSockOpt(&idle)
-	ep.SetSockOpt(&interval)
-	ep.SetSockOptInt(tcpip.KeepaliveCountOption, count)
+	_ = ep.SetSockOpt(&idle)
+	_ = ep.SetSockOpt(&interval)
+	_ = ep.SetSockOptInt(tcpip.KeepaliveCountOption, count)
 
 	c := &TCPConn{
 		wq: wq,
@@ -358,7 +358,7 @@ func commonRead(ctx context.Context, b []byte, ep tcpip.Endpoint, wq *waiter.Que
 
 	if _, ok := err.(*tcpip.ErrWouldBlock); ok {
 		// Create wait queue entry that notifies a channel.
-		waitEntry, notifyCh := waiter.NewChannelEntry(waiter.ReadableEvents)
+		waitEntry, notifyCh := waiter.NewChannelEntry(0x1f | waiter.EventRdNorm | waiter.EventWrNorm | waiter.EventRdHUp)
 		wq.EventRegister(&waitEntry)
 		defer wq.EventUnregister(&waitEntry)
 		for {


### PR DESCRIPTION
	设置TCP RTO范围, 太大的MaxRTO可能导致tcp keepalive不能被及时触发。tcp endpoint 中是靠
	timer触发keepalive的, 过大的RTO, 可能导致上次设置的timer还没被触发, 又被Reset成更大的时长,
	类似:
	  for i := 1; ; i++ {
	  	timer.Reset(i * 2 * time.Second)
	  	time.Sleep(i * time.Second)
	  }
	